### PR TITLE
Draft: Add `is_search_domain` to DNS results

### DIFF
--- a/internal/bowtie/client/control_plane.go
+++ b/internal/bowtie/client/control_plane.go
@@ -43,6 +43,7 @@ type DNS struct {
 	IsLog            bool                  `json:"is_log"`
 	IsDropA          bool                  `json:"is_drop_a"`
 	IsDropAll        bool                  `json:"is_drop_all"`
+	IsSearchDomain   bool                  `json:"is_search_domain"`
 	DNS64Exclude     map[string]DNSExclude `json:"dns64_exclude"`
 }
 

--- a/internal/bowtie/resources/dns.go
+++ b/internal/bowtie/resources/dns.go
@@ -35,6 +35,7 @@ type dnsResourceModel struct {
 	IsLog            types.Bool                `tfsdk:"is_log"`
 	IsDropA          types.Bool                `tfsdk:"is_drop_a"`
 	IsDropAll        types.Bool                `tfsdk:"is_drop_all"`
+	IsSearchDomain   types.Bool                `tfsdk:"is_search_domain"`
 	DNS64Exclude     []dnsExcludeResourceModel `tfsdk:"excludes"`
 }
 
@@ -124,6 +125,11 @@ func (d *dnsResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				Default:             booldefault.StaticBool(false),
 				Computed:            true,
 				MarkdownDescription: "Should all records be dropped",
+			},
+			"is_search_domain": schema.BoolAttribute{
+				Default:             booldefault.StaticBool(false),
+				Computed:            true,
+				MarkdownDescription: "Should domain be configured as a Search Domain on the client",
 			},
 			"excludes": schema.ListNestedAttribute{
 				MarkdownDescription: "Provider Metadata storing extra API information about the exclude settings",


### PR DESCRIPTION
Caveat here: I don't know what I'm doing in go or terraform providers yet. We're adding a new field in the next release for setting search domains. 